### PR TITLE
Ids fs

### DIFF
--- a/python/EgammaPostRecoTools.py
+++ b/python/EgammaPostRecoTools.py
@@ -609,28 +609,28 @@ def _setupEgammaPostVIDUpdator(eleSrc,phoSrc,cfg):
         
     ###SJ add the SFs
     if cfg.runEgammaEleIDSF:
-        egammaeleIDSFModifierMap = []
+        egammaeleIDSFModifierList = []
         ieleID = 0
         for eleID in cfg.eleIDSFName:
-            egammaeleIDSFModifierMap.append(egammaSFModifier.clone())
-            egammaeleIDSFModifierMap[ieleID] = _setupEgammaEleIDSF(cfg,egammaeleIDSFModifierMap[ieleID], eleID)
+            egammaeleIDSFModifierList.append(egammaSFModifier.clone())
+            egammaeleIDSFModifierList[ieleID] = _setupEgammaEleIDSF(cfg,egammaeleIDSFModifierList[ieleID], eleID)
             print("running EleID SF modifier")
             print "Running phoID with file %s and ID %s "%(egammaSFModifier.elefilename, egammaSFModifier.ele_sf_name)
 
             
-            egamma_modifications.append(egammaeleIDSFModifierMap[ieleID])
+            egamma_modifications.append(egammaeleIDSFModifierList[ieleID])
             ieleID = ieleID+1
 
     if cfg.runEgammaPhoIDSF:
-        egammaphoIDSFModifierMap = []
+        egammaphoIDSFModifierList = []
         print "Running phoID with file %s and ID %s "%(egammaSFModifier.phofilename, egammaSFModifier.pho_sf_name)
         iphoID = 0
         for phoID in cfg.phoIDSFName:
             
-            egammaphoIDSFModifierMap.append(egammaSFModifier.clone()) 
+            egammaphoIDSFModifierList.append(egammaSFModifier.clone()) 
             
-            egammaphoIDSFModifierMap[iphoID] = _setupEgammaPhoIDSF(cfg,egammaphoIDSFModifierMap[iphoID], phoID)
-            egamma_modifications.append(egammaphoIDSFModifierMap[iphoID])
+            egammaphoIDSFModifierList[iphoID] = _setupEgammaPhoIDSF(cfg,egammaphoIDSFModifierList[iphoID], phoID)
+            egamma_modifications.append(egammaphoIDSFModifierList[iphoID])
             iphoID = iphoID + 1
     
     #add any missing variables to the slimmed electron 

--- a/python/EgammaPostRecoTools.py
+++ b/python/EgammaPostRecoTools.py
@@ -48,6 +48,13 @@ _defaultPhoIDModules =  [ 'RecoEgamma.PhotonIdentification.Identification.cutBas
                         'RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring16_V2p2_cff',
                         'RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring16_nonTrig_V1_cff'
                         ]
+
+
+###SJ default ID SFs to be stored
+_defaultEleIDSF = 'mvaEleID-Fall17-noIso-V2-wp80'
+_defaultPhoIDSF = 'cutBasedElectronID-Fall17-94X-V2-tight'
+
+
 if not _isULDataformat:
     #was depreciated due to the new e/gamma dataformat for UL
     _defaultPhoIDModules.insert(1,'RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Fall17_94X_V1_cff')
@@ -111,6 +118,85 @@ def _getEnergyCorrectionFile(era):
     raise LogicError('Error in postRecoEgammaTools, era '+era+' not added to energy corrections function, please update this function')
 
 
+###SJ for SF
+def _getIDSFFile(era):
+    eleSFfile = "RecoEgamma/EgammaTools/data/run2_EleIDs.json"
+    phoSFfile = "RecoEgamma/EgammaTools/data/run2_PhoIDs.json"
+    if era=="2017-UL" or era=="2018-UL":
+        return eleSFfile, phoSFfile
+
+    elif era=="2016-UL":
+        raise RuntimeError('Error in postRecoEgammaTools, 2016-UL is still not done') 
+
+    elif "UL" not in era:
+        raise RuntimeError('Error in postRecoEgammaTools, cannot add SFs pre UL era')
+    
+
+def _getPtEtaBoundaryForIDSF(sfName, era):
+
+    if sfName == "cutBasedElectronID-Fall17-94X-V2-veto":
+        pt_bndrs  = cms.vdouble(10., 20., 35.0, 50., 100., 200., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "cutBasedElectronID-Fall17-94X-V2-loose":
+        pt_bndrs  = cms.vdouble(10., 20., 35.0, 50., 100., 200., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "cutBasedElectronID-Fall17-94X-V2-medium":
+        pt_bndrs  = cms.vdouble(10., 20., 35.0, 50., 100., 200., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "cutBasedElectronID-Fall17-94X-V2-tight":
+        pt_bndrs  = cms.vdouble(10., 20., 35.0, 50., 100., 200., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "mvaEleID-Fall17-noIso-V2-wp80":
+        pt_bndrs  = cms.vdouble(10., 20., 35.0, 50., 100., 200., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "mvaEleID-Fall17-noIso-V2-wp90":
+        pt_bndrs  = cms.vdouble(10., 20., 35.0, 50., 100., 200., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "mvaEleID-Fall17-iso-V2-wp80":
+        pt_bndrs  = cms.vdouble(10., 20., 35.0, 50., 100., 200., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "mvaEleID-Fall17-iso-V2-wp90":
+        pt_bndrs  = cms.vdouble(10., 20., 35.0, 50., 100., 200., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "cutBasedPhotonID-Fall17-94X-V2-loose":
+        pt_bndrs  = cms.vdouble(20., 35.0, 50., 100., 200., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "cutBasedPhotonID-Fall17-94X-V2-medium":
+        pt_bndrs  = cms.vdouble(20., 35.0, 50., 80., 120., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "cutBasedPhotonID-Fall17-94X-V2-tight":
+        pt_bndrs  = cms.vdouble(20., 35.0, 50., 80., 120., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "mvaPhoID-RunIIFall17-v2-wp90":
+        pt_bndrs  = cms.vdouble(20., 35.0, 50., 100., 200., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    elif sfName == "mvaPhoID-RunIIFall17-v2-wp80":
+        pt_bndrs  = cms.vdouble(20., 35.0, 50., 100., 200., 500.)
+        eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+
+###binnning changed a bit in 2018 UL because we had more time to tune
+    if era == "2018-UL":
+        if sfName == "mvaPhoID-RunIIFall17-v2-wp90":
+            pt_bndrs  = cms.vdouble(20., 35.0, 50., 80., 120., 500.)
+            eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+        elif sfName == "mvaPhoID-RunIIFall17-v2-wp80":
+            pt_bndrs  = cms.vdouble(20., 35.0, 50., 80., 120., 500.)
+            eta_bndrs = cms.vdouble(-2.5, -2.0, -1.566, -1.444, -0.8, 0.0, 0.8, 1.444, 1.566, 2.0, 2.5) 
+
+    return pt_bndrs, eta_bndrs
 
 def _isInputFrom80X(era):
     _check_valid_era(era)
@@ -166,6 +252,9 @@ class CfgData:
             'runEnergyCorrections' : True,
             'applyEPCombBug' : False,
             'autoAdjustParams' : True,
+            'runEgammaSF' : True,
+            'eleIDSFName' : _defaultEleIDSF,
+            'phoIDSFName' : _defaultPhoIDSF,
             'process' : None
         }
         #I hate this hack but easiest way to communicate that the preVID updator is running
@@ -422,8 +511,38 @@ def _setupEgammaVID(eleSrc,phoSrc,cfg):
     return eleSrc,phoSrc
 
 
+###SJ SF setup
+def _setupEgammaIDSF(cfg, egammaSFModifier):
+    process = cfg.process
+    eleSFfile, phoSFfile = _getIDSFFile(cfg.era)
+
+    if cfg.era == "2017-UL":
+        egammaSFModifier.year = cms.string("2017")
+    elif cfg.era == "2018-UL":
+        egammaSFModifier.year = cms.string("2018")
+    elif era=="2016-UL":
+        raise RuntimeError('Error in postRecoEgammaTools, 2016-UL is still not done') 
+
+    elif "UL" not in era:
+        raise RuntimeError('Error in postRecoEgammaTools, cannot add SFs pre UL era')
+
+
+    ele_pt_bndrs, ele_eta_bndrs = _getPtEtaBoundaryForIDSF(cfg.eleIDSFName, cfg.era)
+    egammaSFModifier.elefilename = cms.string(os.environ['CMSSW_BASE'] + '/src/%s'%eleSFfile)
+    egammaSFModifier.ele_sf_name = cfg.eleIDSFName
+    egammaSFModifier.ele_pt_bndrs = ele_pt_bndrs
+    egammaSFModifier.ele_eta_bndrs = ele_eta_bndrs
+
+    pho_pt_bndrs, pho_eta_bndrs = _getPtEtaBoundaryForIDSF(cfg.phoIDSFName, cfg.era)
+    egammaSFModifier.phofilename = cms.string(os.environ['CMSSW_BASE'] + '/src/%s'%phoSFfile)
+    egammaSFModifier.pho_sf_name = cfg.phoIDSFName
+    egammaSFModifier.pho_pt_bndrs = pho_pt_bndrs
+    egammaSFModifier.pho_eta_bndrs = pho_eta_bndrs
+
+    
+
 def _setupEgammaPostVIDUpdator(eleSrc,phoSrc,cfg):
-    from RecoEgamma.EgammaTools.egammaObjectModificationsInMiniAOD_cff import egamma_modifications,egamma8XLegacyEtScaleSysModifier
+    from RecoEgamma.EgammaTools.egammaObjectModificationsInMiniAOD_cff import egamma_modifications,egamma8XLegacyEtScaleSysModifier, egammaSFModifier
     from RecoEgamma.EgammaTools.egammaObjectModifications_tools import makeVIDBitsModifier,makeVIDinPATIDsModifier,makeEnergyScaleAndSmearingSysModifier  
     process = cfg.process
 
@@ -442,6 +561,15 @@ def _setupEgammaPostVIDUpdator(eleSrc,phoSrc,cfg):
         egamma_modifications.append(makeEnergyScaleAndSmearingSysModifier("calibratedPatElectrons","calibratedPatPhotons"))
         egamma_modifications.append(egamma8XLegacyEtScaleSysModifier)
         
+    ###SJ add the SFs
+    if cfg.runEgammaSF:
+        print("running SF modifier")
+        _setupEgammaIDSF(cfg,egammaSFModifier)
+     
+        print "Running eleID with file %s and ID %s "%(egammaSFModifier.elefilename, egammaSFModifier.ele_sf_name)
+        print "Running phoID with file %s and ID %s "%(egammaSFModifier.phofilename, egammaSFModifier.pho_sf_name)
+        
+        egamma_modifications.append(egammaSFModifier)
 
     
     #add any missing variables to the slimmed electron 
@@ -545,6 +673,9 @@ def setupEgammaPostRecoSeq(process,
                            runVID=True,
                            runEnergyCorrections=True,
                            applyEPCombBug=False,
+                           runEgammaSF=True,
+                           eleIDSFName=_defaultEleIDSF,
+                           phoIDSFName=_defaultPhoIDSF,
                            autoAdjustParams=True):
     #first check if we are running in a valid release, will throw if not
     _validRelease()
@@ -572,20 +703,20 @@ def setupEgammaPostRecoSeq(process,
 
 
 
-    _setupEgammaPostRecoSeq(process,applyEnergyCorrections=applyEnergyCorrections,applyVIDOnCorrectedEgamma=applyVIDOnCorrectedEgamma,era=era,runVID=runVID,runEnergyCorrections=runEnergyCorrections,applyEPCombBug=applyEPCombBug,isMiniAOD=isMiniAOD)
+    _setupEgammaPostRecoSeq(process,applyEnergyCorrections=applyEnergyCorrections,applyVIDOnCorrectedEgamma=applyVIDOnCorrectedEgamma,era=era,runVID=runVID,runEnergyCorrections=runEnergyCorrections,applyEPCombBug=applyEPCombBug,isMiniAOD=isMiniAOD,runEgammaSF=runEgammaSF,eleIDSFName=eleIDSFName, phoIDSFName=phoIDSFName)
     
 
     return process
 
 
-def makeEgammaPATWithUserData(process,eleTag=None,phoTag=None,runVID=True,runEnergyCorrections=True,era="2017-Nov17ReReco",suffex="WithUserData"):
+def makeEgammaPATWithUserData(process,eleTag=None,phoTag=None,runVID=True,runEnergyCorrections=True,runEgammaSF=True,era="2017-Nov17ReReco",suffex="WithUserData"):
     """
     This function embeds the value maps into a pat::Electron,pat::Photon
     This function is not officially supported by e/gamma and is on a best effort bais
     eleTag and phoTag are type cms.InputTag
     outputs new collection with {eleTag/phoTag}.moduleLabel + suffex 
     """
-    from RecoEgamma.EgammaTools.egammaObjectModificationsInMiniAOD_cff import egamma_modifications,egamma8XLegacyEtScaleSysModifier,egamma8XObjectUpdateModifier
+    from RecoEgamma.EgammaTools.egammaObjectModificationsInMiniAOD_cff import egamma_modifications,egamma8XLegacyEtScaleSysModifier,egamma8XObjectUpdateModifier, egammaSFModifier
     from RecoEgamma.EgammaTools.egammaObjectModifications_tools import makeVIDBitsModifier,makeVIDinPATIDsModifier,makeEnergyScaleAndSmearingSysModifier  
     if runVID:
         egamma_modifications.append(makeVIDBitsModifier(process,"egmGsfElectronIDs","egmPhotonIDs"))
@@ -598,6 +729,10 @@ def makeEgammaPATWithUserData(process,eleTag=None,phoTag=None,runVID=True,runEne
         egamma_modifications.append(makeEnergyScaleAndSmearingSysModifier("calibratedElectrons","calibratedPhotons"))
         egamma_modifications.append(egamma8XLegacyEtScaleSysModifier)
     
+    if runEgammaSF:
+        print("running SF modifier")
+        egamma_modifications.append(egammaSFModifier)
+
     process.egammaPostRecoPatUpdatorTask = cms.Task()
 
     if eleTag:

--- a/python/EgammaPostRecoTools.py
+++ b/python/EgammaPostRecoTools.py
@@ -560,8 +560,6 @@ def _setupEgammaEleIDSF(cfg, egammaSFModifiertmp, idname):
     egammaSFModifiertmp.ele_pt_bndrs = pt_bndrs
     egammaSFModifiertmp.ele_eta_bndrs = eta_bndrs
 
-    print "Printing eleID SF modifier"
-    print egammaSFModifiertmp
     return egammaSFModifiertmp
 
 def _setupEgammaPhoIDSF(cfg, egammaSFModifiertmp, idname):
@@ -614,8 +612,7 @@ def _setupEgammaPostVIDUpdator(eleSrc,phoSrc,cfg):
         for eleID in cfg.eleIDSFName:
             egammaeleIDSFModifierList.append(egammaSFModifier.clone())
             egammaeleIDSFModifierList[ieleID] = _setupEgammaEleIDSF(cfg,egammaeleIDSFModifierList[ieleID], eleID)
-            print("running EleID SF modifier")
-            print "Running phoID with file %s and ID %s "%(egammaSFModifier.elefilename, egammaSFModifier.ele_sf_name)
+#            print "Running eleID with file %s and ID %s "%(egammaSFModifier.elefilename, egammaSFModifier.ele_sf_name)
 
             
             egamma_modifications.append(egammaeleIDSFModifierList[ieleID])
@@ -623,7 +620,7 @@ def _setupEgammaPostVIDUpdator(eleSrc,phoSrc,cfg):
 
     if cfg.runEgammaPhoIDSF:
         egammaphoIDSFModifierList = []
-        print "Running phoID with file %s and ID %s "%(egammaSFModifier.phofilename, egammaSFModifier.pho_sf_name)
+#        print "Running phoID with file %s and ID %s "%(egammaSFModifier.phofilename, egammaSFModifier.pho_sf_name)
         iphoID = 0
         for phoID in cfg.phoIDSFName:
             

--- a/python/EgammaPostRecoTools.py
+++ b/python/EgammaPostRecoTools.py
@@ -13,7 +13,7 @@ def _validRelease():
     allowedVersions = { 8 : [0],
                         9 : [4],
                         10 : [2,6],
-                        11 : [0]
+                        11 : [0,1]
                         }
                 
     if majorVersion not in allowedVersions:
@@ -25,7 +25,13 @@ def _validRelease():
 
 def _isULDataformat():
     cmsswVersion =_getCMSSWVersion()
-    return int(cmsswVersion[0]) >= 10 and int(cmsswVersion[1]) >= 5        
+    isUL = (int(cmsswVersion[0]) >= 10 and int(cmsswVersion[1]) >= 5) or (int(cmsswVersion[0]) >=11)
+    return isUL
+
+
+def _CMSSWGT11():
+    cmsswVersion =_getCMSSWVersion()
+    return int(cmsswVersion[0]) >=11
 
 
 #define the default IDs to produce in VID
@@ -78,7 +84,7 @@ else:
     print "EgammaPostRecoTools: Fall17V2 cut based Photons ID modules not found, running ID without them. If you want Fall17V2 CutBased Photon IDs, please merge the approprate PR\n  94X:  git cms-merge-topic cms-egamma/EgammaID_949\n  102X: git cms-merge-topic cms-egamma/EgammaID_1023"
 
 def _check_valid_era(era):
-    valid_eras = ['2017-Nov17ReReco','2016-Legacy','2016-Feb17ReMiniAOD','2018-Prompt','2017-UL']
+    valid_eras = ['2017-Nov17ReReco','2016-Legacy','2016-Feb17ReMiniAOD','2018-Prompt','2016-UL', '2017-UL', '2018-UL']
     if era not in valid_eras:
         raise RuntimeError('error, era {} not in list of allowed eras {}'.format(value,str(valid_eras)))
     return True
@@ -95,8 +101,16 @@ def _getEnergyCorrectionFile(era):
     if era=="2018-Prompt":
         return "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_Step2Closure_CoarseEtaR9Gain_v2"
     if era=="2017-UL":
-        raise RuntimeError('Error in postRecoEgammaTools, era 2017-UL does not yet have energy corrections, please contact the e/gamma pog for more information')
+        return "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_24Feb2020_runEtaR9Gain_v2"
+    if era=="2018-UL":
+        return "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_13Apr2020_RunEtaR9Gain_v2"
+        
+    if era=="2016-UL":
+        raise RuntimeError('Error in postRecoEgammaTools, era 2016-UL does not yet have energy corrections, please contact the e/gamma pog for more information')
+
     raise LogicError('Error in postRecoEgammaTools, era '+era+' not added to energy corrections function, please update this function')
+
+
 
 def _isInputFrom80X(era):
     _check_valid_era(era)
@@ -152,7 +166,6 @@ class CfgData:
             'runEnergyCorrections' : True,
             'applyEPCombBug' : False,
             'autoAdjustParams' : True,
-            'computeHeepTrkPtIso' : True,
             'process' : None
         }
         #I hate this hack but easiest way to communicate that the preVID updator is running
@@ -222,10 +235,15 @@ def _setupEgammaPreVIDUpdator(eleSrc,phoSrc,cfg):
             process.load('RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationMiniAOD_cff')
             phoIsoTask = process.egmPhotonIsolationMiniAODTask 
             process.heepIDVarValueMaps.elesMiniAOD = eleSrc
-            process.photonIDValueMapProducer.srcMiniAOD = phoSrc
+            if not _CMSSWGT11(): 
+                process.photonIDValueMapProducer.srcMiniAOD = phoSrc
+                process.photonIDValueMapProducer.src = cms.InputTag("") 
+            else:
+                process.photonIDValueMapProducer.src = phoSrc 
             #now disabling miniAOD/AOD auto detection...
             process.heepIDVarValueMaps.dataFormat = 2 
-            process.photonIDValueMapProducer.src = cms.InputTag("") 
+            
+            
             
         else:
             raise Exception("EgammaPostRecoTools: It is currently not possible to read AOD produced pre 106X in 106X+, please email e/gamma pog to get a resolution") 
@@ -310,6 +328,7 @@ def _setupEgammaEnergyCorrections(eleSrc,phoSrc,cfg):
     eleCalibProd.correctionFile = energyCorrectionFile
     phoCalibProd.correctionFile = energyCorrectionFile
 
+
     if cfg.applyEPCombBug and hasattr(eleCalibProd,'useSmearCorrEcalEnergyErrInComb'):
         eleCalibProd.useSmearCorrEcalEnergyErrInComb=True
     elif hasattr(eleCalibProd,'useSmearCorrEcalEnergyErrInComb'):
@@ -323,7 +342,7 @@ def _setupEgammaEnergyCorrections(eleSrc,phoSrc,cfg):
     if cfg.applyEnergyCorrections or cfg.applyVIDOnCorrectedEgamma:
         eleCalibProd.produceCalibratedObjs = True
         phoCalibProd.produceCalibratedObjs = True
-        return cms.InputTag(eleCalibName),cms.InputTag(eleCalibName)
+        return cms.InputTag(eleCalibName),cms.InputTag(phoCalibName)
     else:
         eleCalibProd.produceCalibratedObjs = False 
         phoCalibProd.produceCalibratedObjs = False 
@@ -335,7 +354,7 @@ def _setupEgammaVID(eleSrc,phoSrc,cfg):
     process.egammaVIDTask = cms.Task()
     if cfg.runVID:
         #heep value map needs to be manually added to the task
-        if not _isULDataformat() and cfg.computeHeepTrkPtIso:
+        if not _isULDataformat():
             import RecoEgamma.ElectronIdentification.Identification.heepElectronID_tools as heep_tools
             heep_tools.addHEEPProducersToSeq(process,cms.Sequence(),cfg.isMiniAOD,process.egammaVIDTask)
         process.egammaVIDTask.add(process.egmGsfElectronIDTask)
@@ -346,12 +365,17 @@ def _setupEgammaVID(eleSrc,phoSrc,cfg):
         process.egmPhotonIDs.physicsObjectSrc = phoSrc
 
         if cfg.isMiniAOD:
-            process.electronMVAValueMapProducer.srcMiniAOD = eleSrc
-            process.photonMVAValueMapProducer.srcMiniAOD = phoSrc 
+            if not _CMSSWGT11():
+                process.electronMVAValueMapProducer.srcMiniAOD = eleSrc
+                process.photonMVAValueMapProducer.srcMiniAOD = phoSrc 
             #we need to also zero out the AOD srcs as otherwise it gets confused in two tier jobs
             #and bad things happen
-            process.electronMVAValueMapProducer.src = cms.InputTag("")
-            process.photonMVAValueMapProducer.src = cms.InputTag("")
+                process.electronMVAValueMapProducer.src = cms.InputTag("")
+                process.photonMVAValueMapProducer.src = cms.InputTag("") 
+            else:
+                process.electronMVAValueMapProducer.src = eleSrc
+                process.photonMVAValueMapProducer.src = phoSrc
+
         else:
             process.electronMVAValueMapProducer.src = eleSrc
             process.photonMVAValueMapProducer.src = phoSrc 
@@ -361,11 +385,15 @@ def _setupEgammaVID(eleSrc,phoSrc,cfg):
             
         if hasattr(process,'electronMVAVariableHelper'):
             if cfg.isMiniAOD:
-                process.electronMVAVariableHelper.srcMiniAOD = eleSrc
-                process.electronMVAVariableHelper.src = cms.InputTag("")
+                if not _CMSSWGT11():
+                    process.electronMVAVariableHelper.srcMiniAOD = eleSrc
+                    process.electronMVAVariableHelper.src = cms.InputTag("")
+                else:    
+                    process.electronMVAVariableHelper.src = eleSrc
             else:
                 process.electronMVAVariableHelper.src = eleSrc
                 process.electronMVAVariableHelper.srcMiniAOD = cms.InputTag("")
+                
 
         #pre UL dataformat, we have to run the egmPhotonIsolation and the like as part of vid
         #post UL dataformat its in the object, how if we are reading old data it will be running
@@ -373,8 +401,11 @@ def _setupEgammaVID(eleSrc,phoSrc,cfg):
         if not _isULDataformat():
             process.egmPhotonIsolation.srcToIsolate = phoSrc
             if cfg.isMiniAOD:
-                process.photonIDValueMapProducer.srcMiniAOD = phoSrc
-                process.photonIDValueMapProducer.src = cms.InputTag("")
+                if not _CMSSWGT11():
+                    process.photonIDValueMapProducer.srcMiniAOD = phoSrc
+                    process.photonIDValueMapProducer.src = cms.InputTag("")
+                else:
+                    process.photonIDValueMapProducer.src = phoSrc
                 if hasattr(process,'heepIDVarValueMaps'):
                     process.heepIDVarValueMaps.elesMiniAOD = eleSrc
                     process.heepIDVarValueMaps.dataFormat = 2
@@ -411,13 +442,14 @@ def _setupEgammaPostVIDUpdator(eleSrc,phoSrc,cfg):
         egamma_modifications.append(makeEnergyScaleAndSmearingSysModifier("calibratedPatElectrons","calibratedPatPhotons"))
         egamma_modifications.append(egamma8XLegacyEtScaleSysModifier)
         
+
     
     #add any missing variables to the slimmed electron 
     if cfg.runVID:
         #MVA V2 values may not be added by default due to data format consistency issues
         _addMissingMVAValuesToUserData(process,egamma_modifications)
         #now add HEEP trk isolation if old dataformat (new its in the object proper)
-        if not _isULDataformat() and cfg.computeHeepTrkPtIso:
+        if not _isULDataformat():
             for pset in egamma_modifications:
                 if pset.hasParameter("modifierName") and pset.modifierName == cms.string('EGExtraInfoModifierFromFloatValueMaps'):
                     pset.electron_config.heepTrkPtIso = cms.InputTag("heepIDVarValueMaps","eleTrkPtIso")
@@ -495,13 +527,13 @@ def _setupEgammaPostRecoSeq(*args,**kwargs):
     process.egammaVIDSeq = cms.Sequence(process.egammaVIDTask)
     process.egammaPostRecoPatUpdatorSeq = cms.Sequence(process.egammaPostRecoPatUpdatorTask)
 
+
     process.egammaPostRecoSeq = cms.Sequence(
         process.egammaUpdatorSeq +
         process.egammaScaleSmearSeq +
         process.egammaVIDSeq + 
         process.egammaPostRecoPatUpdatorSeq
     )
-        
 
 def setupEgammaPostRecoSeq(process,
                            applyEnergyCorrections=False,
@@ -513,11 +545,7 @@ def setupEgammaPostRecoSeq(process,
                            runVID=True,
                            runEnergyCorrections=True,
                            applyEPCombBug=False,
-                           autoAdjustParams=True,
-                           computeHeepTrkPtIso=True):
-    """
-    Note: computeHeepTrkPtIso can't be set to false if you want to run a HEEP ID.
-    """
+                           autoAdjustParams=True):
     #first check if we are running in a valid release, will throw if not
     _validRelease()
 
@@ -538,13 +566,13 @@ def setupEgammaPostRecoSeq(process,
             setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection)
 
     if autoAdjustParams:
-        if era=="2017-UL" and runEnergyCorrections:
-            print "EgammaPostRecoTools:INFO auto adjusting runEnergyCorrections to False as they are not yet availible for 2017-UL, set autoAdjustParams = False to force them to run"
+        if ((era=="2016-UL") and runEnergyCorrections):
+            print "EgammaPostRecoTools:INFO auto adjusting runEnergyCorrections to False as they are not yet availible for 2016-UL, set autoAdjustParams = False to force them to run"
             runEnergyCorrections = False
 
 
 
-    _setupEgammaPostRecoSeq(process,applyEnergyCorrections=applyEnergyCorrections,applyVIDOnCorrectedEgamma=applyVIDOnCorrectedEgamma,era=era,runVID=runVID,runEnergyCorrections=runEnergyCorrections,applyEPCombBug=applyEPCombBug,isMiniAOD=isMiniAOD, computeHeepTrkPtIso=computeHeepTrkPtIso)
+    _setupEgammaPostRecoSeq(process,applyEnergyCorrections=applyEnergyCorrections,applyVIDOnCorrectedEgamma=applyVIDOnCorrectedEgamma,era=era,runVID=runVID,runEnergyCorrections=runEnergyCorrections,applyEPCombBug=applyEPCombBug,isMiniAOD=isMiniAOD)
     
 
     return process

--- a/test/printEgammaUserData.py
+++ b/test/printEgammaUserData.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from DataFormats.FWLite import Events, Handle
+import ROOT    
+import argparse
 
 def convert_to_str(vec_str):
     output = ""
@@ -15,65 +21,69 @@ def convertpair_to_str(vec_str):
     return output
 
 def print_ele_user_data(ele):
-    print "ele userfloats:"
-    print "  "+convert_to_str(ele.userFloatNames())
-    print "ele userints:"
-    print "  "+convert_to_str(ele.userIntNames())
-    print "ele IDs:"
-    print "  "+convertpair_to_str(ele.electronIDs())
+    print("ele userfloats:")
+    print("  "+convert_to_str(ele.userFloatNames()))
+    print("ele userints:")
+    print("  "+convert_to_str(ele.userIntNames()))
+    print("ele IDs:")
+    print("  "+convertpair_to_str(ele.electronIDs()))
 
 def print_pho_user_data(pho):
-    print "pho userfloats:"
-    print "  "+convert_to_str(pho.userFloatNames())
-    print "pho userints:"
-    print "  "+convert_to_str(pho.userIntNames())
-    print "pho IDs:"
-    print "  "+convertpair_to_str(pho.photonIDs())
+    print("pho userfloats:")
+    print("  "+convert_to_str(pho.userFloatNames()))
+    print("pho userints:")
+    print("  "+convert_to_str(pho.userIntNames()))
+    print("pho IDs:")
+    print("  "+convertpair_to_str(pho.photonIDs()))
 
+if __name__ == "__main__":
 
-import sys
-oldargv = sys.argv[:]
-sys.argv = [ '-b-' ]
-import ROOT
-ROOT.gROOT.SetBatch(True)
-sys.argv = oldargv
-ROOT.gSystem.Load("libFWCoreFWLite.so");
-ROOT.gSystem.Load("libDataFormatsFWLite.so");
-ROOT.FWLiteEnabler.enable()
-from DataFormats.FWLite import Events, Handle
-
-import argparse
-parser = argparse.ArgumentParser(description='prints E/gamma pat::Electrons/Photons user data')
-parser.add_argument('filename',help='input filename')
-args = parser.parse_args()
-
-eles, ele_label = Handle("std::vector<pat::Electron>"), "slimmedElectrons"
-phos, pho_label = Handle("std::vector<pat::Photon>"), "slimmedPhotons"
-
-
-min_pho_et = 20
-min_ele_et = 20
-
-done_ele = False
-done_pho = False
-
-events = Events(args.filename)
-for event_nr,event in enumerate(events):
-    if done_ele and done_pho: break
+    """
+    prints electron and photon miniAOD user data
     
-    if not done_pho:
-        event.getByLabel(pho_label,phos)
+    note: it assumes that all electrons and photons have exactly the same userdata so we can just print 
+    the first one. This is currently true except for low pt electrons and photons hence we put a >20 GeV
+    cut on the ele/pho we print
+    """
+    ROOT.gSystem.Load("libFWCoreFWLite.so");
+    ROOT.gSystem.Load("libDataFormatsFWLite.so");
+    ROOT.FWLiteEnabler.enable()
+
+    parser = argparse.ArgumentParser(description='prints E/gamma pat::Electrons/Photons user data')
+    parser.add_argument('filename',help='input filename')
+    args = parser.parse_args()
     
-        for pho_nr,pho in enumerate(phos.product()):  
-            if pho.et()<min_pho_et: continue
-            else:
-                print_pho_user_data(pho)
-                done_pho = True
-    if not done_ele:
-        event.getByLabel(ele_label,eles)
+    eles, ele_label = Handle("std::vector<pat::Electron>"), "slimmedElectrons"
+    phos, pho_label = Handle("std::vector<pat::Photon>"), "slimmedPhotons"
+
+    #we put a minimum et as low et electrons/photons may not have all the variables
+    min_pho_et = 20
+    min_ele_et = 20
     
-        for ele_nr,ele in enumerate(eles.product()):
-            if ele.et()<min_ele_et: continue
-            else:
-                print_ele_user_data(ele)
-                done_ele = True
+    done_ele = False
+    done_pho = False
+
+    events = Events(args.filename)
+    for event_nr,event in enumerate(events):
+        if done_ele and done_pho: break
+        
+        if not done_pho:
+            event.getByLabel(pho_label,phos)
+    
+            for pho_nr,pho in enumerate(phos.product()):  
+                if pho.et()<min_pho_et: 
+                    continue
+                else:
+                    print_pho_user_data(pho)
+                    done_pho = True
+                    break
+
+        if not done_ele:
+            event.getByLabel(ele_label,eles)            
+            for ele_nr,ele in enumerate(eles.product()):
+                if ele.et()<min_ele_et: 
+                    continue
+                else:
+                    print_ele_user_data(ele)
+                    done_ele = True
+                    break

--- a/test/printVIDInfo.py
+++ b/test/printVIDInfo.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import switchOnVIDElectronIdProducer,switchOnVIDPhotonIdProducer,setupAllVIDIdsInModule,DataFormat,setupVIDElectronSelection,setupVIDPhotonSelection
+import argparse
+
+"""
+A simple script which prints out the configuration of the electron/photon VID IDs
+"""
+
+def setupVID(process):
+
+   #define the default IDs to produce in VID
+    from EgammaUser.EgammaPostRecoTools.EgammaPostRecoTools import _defaultEleIDModules,_defaultPhoIDModules
+  
+    #as we're not running, it doesnt matter if its miniAOD or AOD
+    switchOnVIDElectronIdProducer(process,DataFormat.MiniAOD)
+    switchOnVIDPhotonIdProducer(process,DataFormat.MiniAOD)
+    
+    eleIDModules = _defaultEleIDModules
+    phoIDModules = _defaultPhoIDModules
+
+    for idmod in eleIDModules:
+        setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
+    for idmod in phoIDModules:
+        setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection)
+
+def convertPSetToValueDict(pset):
+    """
+    converts a CMSSW PSet to a dictionary of standard python types for easier python manipulation
+    """
+    psetDict={}
+    for paraName,para in pset.parameters_().iteritems():
+        if para.pythonTypeName()=="cms.VPSet":
+            psetDict[paraName]=[convertPSetToValueDict(child) for child in para]
+        elif para.pythonTypeName()=="cms.PSet":
+            psetDict[paraName]=convertPSetToValueDict(para)
+        else:
+            psetDict[paraName]=para.value()
+    return psetDict
+
+def getCutDisplayName(cut):
+    """
+    a function which figures out the display name for a cut
+    this exists to solve the problem where the photon cuts print as PhoGenericRhoPtScaledCut
+    and its hard to figure out which its actually cutting on
+    """
+    cutName = cut.getParameter("cutName").value()
+    if cutName=="PhoGenericRhoPtScaledCut":
+        return "{}:{}".format(cutName,cut.getParameter("cutVariable").value())
+    else:
+        return str(cutName)   
+
+def printMinPtCut(cutCfg,indent=6):
+    print "{}Et > {} ".format(" "*indent,cutCfg.getParameter("minPt").value())
+
+def printGsfEleSCEtaMultiRangeCut(cutCfg,indent=6):
+    etaRanges = cutCfg.getParameter("allowedEtaRanges")
+    outStr = " "*indent
+    isAbs = cutCfg.getParameter("useAbsEta")
+    if isAbs: etaStr = "|eta|"
+    else: etaStr = "eta"
+    for etaRangeNr, etaRange in enumerate(etaRanges):
+        if etaRangeNr!=0: outStr+=" || "
+        outStr += "{} < {} < {}".format(etaRange.getParameter("minEta").value(),etaStr,etaRange.getParameter("maxEta").value())
+    print outStr
+        
+def printGsfEleDEtaInSeedCut(cutCfg,indent=6):
+    print "{}|dEtaInSeed| < {} (EB), {} (EE)".format(" "*indent,cutCfg.getParameter("dEtaInSeedCutValueEB").value(),cutCfg.getParameter("dEtaInSeedCutValueEE").value())
+
+def printGsfEleDPhiInCut(cutCfg,indent=6):
+    print "{}|dPhiIn| < {} (EB), {} (EE)".format(" "*indent,cutCfg.getParameter("dPhiInCutValueEB").value(),cutCfg.getParameter("dPhiInCutValueEE").value())
+
+def printGsfEleFull5x5SigmaIEtaIEtaCut(cutCfg,indent=6):
+    print "{}sigma_ietaieta (full5x5) < {} (EB), {} (EE)".format(" "*indent,cutCfg.getParameter("full5x5SigmaIEtaIEtaCutValueEB").value(),cutCfg.getParameter("full5x5SigmaIEtaIEtaCutValueEE").value())
+
+def printGsfEleFull5x5SigmaIEtaIEtaWithSatCut(cutCfg,indent=6):
+    print "{}sigma_ietaieta (full5x5) < {} (EB), {} (EE) || #nr sat crystals > {} (EB), {} (EE)".format(" "*indent,cutCfg.getParameter("maxSigmaIEtaIEtaEB").value(),cutCfg.getParameter("maxSigmaIEtaIEtaEE").value(),cutCfg.getParameter("maxNrSatCrysIn5x5EB").value(),cutCfg.getParameter("maxNrSatCrysIn5x5EE").value())
+
+def printGsfEleFull5x5E2x5OverE5x5WithSatCut(cutCfg,indent=6):
+    print "{}E2x5Max/E5x5 (full5x5) > {} (EB), {} (EE) || E1x5/E5x5 > {} (EB), {} (EE) || #nr sat crystals > {} (EB), {} (EE)".format(" "*indent,cutCfg.getParameter("minE2x5OverE5x5EB").value(),cutCfg.getParameter("minE2x5OverE5x5EE").value(),cutCfg.getParameter("minE1x5OverE5x5EB").value(),cutCfg.getParameter("minE1x5OverE5x5EE").value(),cutCfg.getParameter("maxNrSatCrysIn5x5EB").value(),cutCfg.getParameter("maxNrSatCrysIn5x5EE").value())
+
+def printGsfEleHadronicOverEMCut(cutCfg,indent=6):
+    print "{}|H/E (cone=0.15) < {} (EB), {} (EE)".format(" "*indent,cutCfg.getParameter("hadronicOverEMCutValueEB").value(),cutCfg.getParameter("hadronicOverEMCutValueEE").value())
+
+def printGsfEleHadronicOverEMEnergyScaledCut(cutCfg,indent=6):
+    print "{}|H/E (cone=0.15) < {} + {}/Esc + {}*{}/Esc (EB)".format(" "*indent,cutCfg.getParameter("barrelC0").value(),cutCfg.getParameter("barrelCE").value(),cutCfg.getParameter("barrelCr").value(),cutCfg.getParameter("rho").value())
+    print "{}|H/E (cone=0.15) < {} + {}/Esc + {}*{}/Esc (EE)".format(" "*indent,cutCfg.getParameter("endcapC0").value(),cutCfg.getParameter("endcapCE").value(),cutCfg.getParameter("endcapCr").value(),cutCfg.getParameter("rho").value())
+
+def printGsfEleHadronicOverEMLinearCut(cutCfg,indent=6):
+    cfgDict = convertPSetToValueDict(cutCfg)
+    cfgDict['indent'] = " "*indent
+    if cutCfg.slopeStartEB.value()==0.0:
+        print "{indent}H/E (cone=0.15) < {slopeTermEB} - {constTermEB}/Esc (EB)".format(**cfgDict)
+    else:
+        print "{indent}H/E (cone=0.15) < {constTermEB}/Esc - {slopeTermEB} * max(0,Esc - {slopeStartEB} (EB))".format(**cfgDict)
+    if cutCfg.slopeStartEE.value()==0.0:
+        print "{indent}H/E (cone=0.15) < {slopeTermEE} - {constTermEE}/Esc (EE)".format(**cfgDict)
+    else:
+        print "{indent}H/E (cone=0.15) < {constTermEE}/Esc - {slopeTermEE} * max(0,Esc - {slopeStartEE} (EE))".format(**cfgDict)
+
+
+def printGsfEleEInverseMinusPInverseCut(cutCfg,indent=6):
+    print "{}|1/E - 1/p < {} (EB), {} (EE)".format(" "*indent,cutCfg.getParameter("eInverseMinusPInverseCutValueEB").value(),cutCfg.getParameter("eInverseMinusPInverseCutValueEE").value())
+
+def printGsfEleEffAreaPFIsoCut(cutCfg,indent=6):
+    isRelIso = cutCfg.getParameter("isRelativeIso")
+    print "{}iso = pf charged + std::max(0,pf neutral+ pf photon - {}*EA)".format(" "*indent,cutCfg.getParameter("rho").value())
+    isoStr = "iso"
+    if isRelIso: isoStr+="/pt"
+
+    isoCutEBLowPt =  cutCfg.getParameter("isoCutEBLowPt").value()
+    isoCutEELowPt =  cutCfg.getParameter("isoCutEELowPt").value()
+    isoCutEBHighPt =  cutCfg.getParameter("isoCutEBHighPt").value()
+    isoCutEEHighPt =  cutCfg.getParameter("isoCutEEHighPt").value()
+    ptCutOff = cutCfg.getParameter("ptCutOff").value()
+
+    if (isoCutEBLowPt == isoCutEBHighPt and isoCutEELowPt == isoCutEEHighPt) or ptCutOff<=0:
+        print "{}{} < {} (EB) < {} (EE) ".format(" "*indent,isoStr,isoCutEBHighPt,isoCutEEHighPt)
+    else:
+        print "{}pt < {} GeV".format(" "*indent,ptCutOff)
+        print "{}{} < {} (EB) < {} (EE) ".format(" "*(indent+2),isoStr,isoCutEBLowPt,isoCutEELowPt)
+        print "{}pt >= {} GeV".format(" "*indent,ptCutOff)
+        print "{}{} < {} (EB) < {} (EE) ".format(" "*(indent+2),isoStr,isoCutEBHighPt,isoCutEEHighPt)
+
+def printGsfEleEmHadD1IsoRhoCut(cutCfg,indent=6):
+    cfgDict = convertPSetToValueDict(cutCfg)
+    cfgDict['indent'] = " "*indent
+    printStr = "{{indent}}isol em + had depth1 < {{constTerm{region}}} + {{slopeTerm{region}}} * min(0,Et-{{slopeStart{region}}} + {{rhoConstant}}*rho ({region})"
+    print printStr.format(region="EB").format(**cfgDict)
+    print printStr.format(region="EE").format(**cfgDict)
+    print "{}rho = {}, energy = {}".format(" "*indent,cutCfg.getParameter("rho").value(),cutCfg.getParameter("energyType").value())
+
+def printGsfEleTrkPtIsoCut(cutCfg,indent=6):
+    varStr = "trk isol (heep)" if cutCfg.useHEEPIso.value() else "trk isol"
+    if cutCfg.slopeTermEB.value()==0.0 and cutCfg.slopeTermEE.value()==0.0:
+        print "{}{} < {} (EB), {} (EE)".format(" "*indent,varStr,cutCfg.getParameter("constTermEB").value(),cutCfg.getParameter("constTermEE").value())
+    else:
+        cfgDict = convertPSetToValueDict(cutCfg)
+        cfgDict['varStr'] = varStr
+        cfgDict['indent'] = " "*indent
+        printStr = "{{indent}} {{varStr}} < {{constTerm{region}}} + {{slopeTerm{region}}} * min(0,Et-{{slopeStart{region}}} ({region})"
+        print printStr.format(region="EB").format(**cfgDict)
+        print printStr.format(region="EE").format(**cfgDict)
+        
+def printGsfEleRelPFIsoScaledCut(cutCfg,indent=6):
+    varStr = "isol = charged + max(0.0,neutral + photon - rho*EA(eta_SC)"
+    cfgDict = convertPSetToValueDict(cutCfg)
+    cfgDict['varStr'] = varStr
+    cfgDict['indent'] = " "*indent
+    print "{indent}{varStr} < {barrelCpt} + {barrelC0} * pt (EB)".format(**cfgDict)
+    print "{indent}{varStr} < {endcapCpt} + {endcapC0} * pt (EE)".format(**cfgDict)
+    
+
+def printGsfEleConversionVetoCut(cutCfg,indent=6):
+    print '{}electron does not match a good conversion in "{}" / "{}"'.format(" "*indent,cutCfg.getParameter("conversionSrc").value(),cutCfg.getParameter("conversionSrcMiniAOD").value())
+    print '{}with beamspot contraint : "{}"'.format(" "*indent,cutCfg.getParameter("beamspotSrc").value())
+
+def printGsfEleMissingHitsCut(cutCfg,indent=6):
+    print "{}#missing hits <= {} (EB), {} (EE)".format(" "*indent,cutCfg.getParameter("maxMissingHitsEB").value(),cutCfg.getParameter("maxMissingHitsEE").value())   
+
+def printGsfEleDxyCut(cutCfg,indent=6):
+    print "{}|dxy| < {} (EB), {} (EE)".format(" "*indent,cutCfg.getParameter("dxyCutValueEB").value(),cutCfg.getParameter("dxyCutValueEE").value())   
+    print "{}dxy w.r.t to leading vertex of {} (AOD) or {} (MINIAOD)".format(" "*indent,cutCfg.getParameter("vertexSrc").value(),cutCfg.getParameter("vertexSrcMiniAOD").value())   
+
+def printGsfEleEcalDrivenCut(cutCfg,indent=6):
+    ebVal = cutCfg.getParameter("ecalDrivenEB")
+    eeVal = cutCfg.getParameter("ecalDrivenEE")
+    if ebVal==-1:
+        ebStr = "no requirement"
+    elif ebVal==0:
+        ebStr = "!isEcalDriven()"
+    elif ebVal==1:
+        ebStr = "isEcalDriven()"
+    if eeVal==-1:
+        eeStr = "no requirement"
+    elif eeVal==0:
+        eeStr = "!isEcalDriven()"
+    elif eeVal==1:
+        eeStr = "isEcalDriven()"
+    print "{}{} (EB), {}(EE)".format(" "*indent,ebStr,eeStr)
+    
+        
+
+def printGsfEleMVAExpodScalingCut(cutCfg,indent=6):
+    return
+    print "{}the cut values of this cut are difficult to succinctly express and so it is not supported by this tool".format(" "*indent)
+    print "{}if you really need the values, please contact e/gamma".format(" "*indent)
+
+def printGsfEleMVACut(cutCfg,indent=6):
+    return
+    print "{}the cut values of this cut are difficult to succinctly express and so it is not supported by this tool".format(" "*indent)
+    print "{}if you really need the values, please contact e/gamma".format(" "*indent)
+
+def printPhoSCEtaMultiRangeCut(cutCfg,indent=6):
+    etaStr = "|eta|" if cutCfg.useAbsEta.value() else "eta"
+    for etaRange in cutCfg.allowedEtaRanges:
+        print "{}{} <= {} < {}".format(" "*indent,etaRange.minEta.value(),etaStr,etaRange.maxEta.value())
+
+def printPhoSingleTowerHadOverEmCut(cutCfg,indent=6):
+    print "{}H/E (single tower) < {} (EB), {} (EE)".format(" "*indent,cutCfg.getParameter("hadronicOverEMCutValueEB").value(),cutCfg.getParameter("hadronicOverEMCutValueEE").value())
+
+def printPhoFull5x5SigmaIEtaIEtaCut(cutCfg,indent=6):
+    print "{}sigma_ietaieta (full5x5) < {} (EB), {} (EE)".format(" "*indent,cutCfg.getParameter("cutValueEB").value(),cutCfg.getParameter("cutValueEE").value())
+
+def printPhoGenericRhoPtScaledCut(cutCfg,indent=6):
+    cfgDict = convertPSetToValueDict(cutCfg)
+    cfgDict['opStr'] = '<' if cutCfg.lessThan.value() else ">="
+    cfgDict['indent'] = " "*indent
+    print "{indent}{cutVariable} {opStr} {constTermEB} + {linearPtTermEB}*Et + EA(|eta|)*rho + {quadPtTermEB}*Et*Et (EB)".format(**cfgDict)
+    print "{indent}{cutVariable} {opStr} {constTermEE} + {linearPtTermEE}*Et + EA(|eta|)*rho + {quadPtTermEE}*Et*Et (EE)".format(**cfgDict)
+    
+def printPhoMVACut(cutCfg,indent=6):
+    print "{} {} > {}".format(" "*indent,cutCfg.mvaValueMapName.getProductInstanceLabel(),cutCfg.mvaCuts.value()) 
+
+def processCut(cutCfg,indent=6):
+    cutName = cutCfg.getParameter("cutName").value()
+    if "print"+cutName in globals():
+        globals()["print"+cutName](cutCfg,indent=7)
+    else:
+        print "{}cut {} does not have a defined print function print{}, please add it".format(" "*indent,cutName,cutName)
+        print cutCfg.parameters_()
+
+def printListOfAvailableIDs(vidProducer):
+    availableIDs = [cfg.getParameter("idDefinition").idName.value() for cfg in vidProducer.physicsObjectIDs]
+    print "availible IDs are:"
+    for idName in availableIDs:
+        print "   {}".format(idName)
+        
+def _printID(idConfig,printCutValues=True):
+    idDef = idConfig.getParameter("idDefinition")
+    idName = idDef.idName.value()
+    headerStr = "   {:^2} {:<42} {:^9} {:^9}"
+    bodyStr   = "   {:^2} {:<42} {:^9} {:^9}"
+    if printCutValues:
+        headerStr = "   {} {} {} {}"
+        bodyStr   = "   {} {} {} {}"
+
+    if not printCutValues:
+        print idName
+        print headerStr.format("#","cutname","mask(dec)","mask(hex)")
+    else:
+        print "{} ({},{},{},{})".format(idName,"#","cutname","mask(dec)","mask(hex)")
+    for cutNr,cut in enumerate(idDef.getParameter("cutFlow")):
+        bitMask = 0x1 << cutNr
+        
+        print bodyStr.format(cutNr,getCutDisplayName(cut),bitMask,hex(bitMask))
+        if printCutValues:
+            processCut(cut)
+
+
+def printAllIDs(vidProducer,printCutValues=True):
+    for idConfig in vidProducer.physicsObjectIDs:
+        _printID(idConfig,printCutValues)
+
+def printID(vidProducer,idName,printCutValues=True):
+    availableIDs = [cfg.getParameter("idDefinition").idName.value() for cfg in vidProducer.physicsObjectIDs]
+    if idName in availableIDs:
+        for idConfig in vidProducer.physicsObjectIDs:
+            if idName==idConfig.getParameter("idDefinition").idName.value():
+                _printID(idConfig,printCutValues)
+                break
+    else:
+        print "{} not found".format(idName)
+        printListOfAvailableIDs(vidProducer)
+            
+
+def main():
+
+    parser = argparse.ArgumentParser(description='prints E/gamma VID info')
+    parser.add_argument('--obj',default="ele",choices=["ele","pho"],help="displays electron or photon IDs")
+    parser.add_argument('--idname',default=None,help="ID to print otherwise prints all IDs")
+    parser.add_argument('--values',action='store_true',help="prints the cut values")
+    parser.add_argument('--listids',action='store_true',help="lists the availible IDs")
+    args = parser.parse_args()
+
+    # set up process
+    process = cms.Process("VIDDump")
+    setupVID(process)
+    
+    if args.obj=="ele":
+        #eleVIDModule = getEleVIDModule(process)
+        vidModule = process.egmGsfElectronIDs
+    elif args.obj=="pho":
+        vidModule = process.egmPhotonIDs
+
+    if args.listids:
+        print "printing available IDs and exiting"
+        printListOfAvailableIDs(vidModule)
+    elif args.idname:
+        printID(vidModule,args.idname,args.values)
+    else:
+        printAllIDs(vidModule,args.values)
+            
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hi Sam,

As we discussed, I have now ported changes from Francesco M. and Vinzenz Stampf. It was good to see that the base was there - only a few debugs + porting to EgammaPostRecoTools.
I started with the CMSDAS2020 version of EgammaPostRecoTools.py which I assume had Jonas's last commits and my UL scale/smearing updates. 

Here is the setup needed:
https://github.com/jainshilpi/cmssw/tree/IDSFs

and the slides from the main developers: https://indico.cern.ch/event/842077/contributions/3633040/attachments/1941671/3219683/egm_08Nov19.pdf

Files added:
(1) RecoEgamma/EgammaTools/plugins/EGammaSFModifier.cc
(2) RecoEgamma/EgammaTools/plugins/json_wrapper.cc
(3) RecoEgamma/EgammaTools/interface/json_wrapper.h
(4) ecoEgamma/EgammaTools/data/run2_PhoIDs.json
(5) ecoEgamma/EgammaTools/data/run2_EleIDs.json

Code modified:
(1) RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py

This currently gives only 1 set of ele and pho SFs at a time.
Probably EgammaPostRecoTools can be adapted to run this for several 
SFs in loop? 

The EgammaPostRecoTools is setup to deal with UL2017 and UL2018 ID SFs. 
The remaining : ele reco SFs and photon veto SFs are still needed to be done. 

I think the setup can be improved e.g. json_wrapper.cc can be modified a bit by giving the input json file name to 
constructor.

Please let me know if you have any suggestions to it.

For now, this setup works and printouts give expected result. We need to just plot the 2D SF plot in one go to be sure of all the pT, eta and ID bins. 

Thanks,
Shilpi


Setup to convert to JSON: https://github.com/cms-egamma/json_converter_egID


